### PR TITLE
Cleanup README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Features 
 
-* Focus on the user assignment side
+* Focus on user assignment
 * Decoupled from user domain
 * Real-time hash-based assignment
 * Experiment evolution with consistent user assignments
@@ -16,24 +16,34 @@
 * Modular and lightweight
 
 
-### Focus on the user assignment side
+### Focus on user assignment
 
 There are 6 logic steps to run an A/B test: 
-1. define an experiment with groups
-2. determine which users are eligible to be in the experiment
-3. randomly assign users to different groups
-4. give users the treatment based on their assignment
-5. report subsequent actions/events from the users together with their assignment
-6. analyze the results and try draw conclusions regarding the effects of the treatments
+1. Define an experiment with user groups
+2. Determine which users are eligible to be in the experiment
+3. Randomly assign users to groups
+4. Give users a treatment based on their assigned group
+5. Report subsequent actions/events from the users with their assignments
+6. Analyze the results and try draw conclusions on the effects of the treatments
 
-At the moment, Thomas focuses on step 1 and 3. It supports step 2 through a tag/meta matching mechanism. It supports step 4 by providing an HTTP service to retrieve user assignments. There is a plan for Thomas to support step 6 in some capacity in the future. For step 5, i.e., reporting/analytics, users of Thomas will need to use an analytics service such as Adobe Analytics, tableau or Google Analytics. 
+At the moment, Thomas focuses on step 1 and 3. 
+
+It supports step 2 through a tag/meta matching mechanism. 
+
+It supports step 4 by providing an HTTP service to retrieve user assignments. 
+
+For step 5, i.e., reporting/analytics, users of Thomas will need to use an analytics service such as Adobe Analytics, tableau or Google Analytics. 
+
+Thomas may support step 6 in some capacity in the future. 
 
 ### Experiment evolution with consistent user assignments
-Sometimes we want to expand an experiment with more users getting the treatment or add new treatments, but don't want to reshuffle the user assignments which affects the users already getting the treatment.  I.e., we want to keep as many users' experiences unchanged as possible.  For example, suppose we start an experiment with 10% of users going to the treatment group, and for whatever reason, we want to expand that to 20% of the users. We would want the original 10% users to remain in the treatment group to avoid their experience being disrupted. Thomas supports this kind of experiment evolution with consistent user assignments. 
+When an experiments userbase or treatments groups need to be modified, it is often preferable not to reassign existing users. Thomas supports this kind of experiment evolution with consistent user assignments. 
 
-By default, when you evolve an experiment with different group composition, Thomas will keep the assignment as consistent as prior group composition as possible.  For groups that are enlarged, i.e., receive a higher percentage of the total population, all users that were assigned to this group previously will remain in it, meaning no treatment change to them. For groups that are shrunk, i.e., receives a lower percentage of the total population, obviously, some users will have to leave this group, but no new users will be added to this group. All users in the newly adjusted group were previously assigned to this group. I.e., no one in the new smaller group experiences a treatment change. 
+By default, when an experiment is evolved with a different group composition, Thomas will change the group composition as little as possible. 
 
-This enables Thomas to also support feature roll out. You can start with a small treatment group and systematically increase its size to roll out a feature gradually. 
+Users in groups that are enlarged will not be reassigned. Users in groups that are shrunk will only be reassigned as necessary to meet the size requirement.
+
+This enables Thomas to support feature roll out. A small treatment group can be increase its size to roll out a feature gradually. 
 
 ### Real-time assignments
 
@@ -45,15 +55,15 @@ The user assignment is a stochastic and deterministic mathematic function. The i
 
 ### Decoupled from user domain
 
-Thomas took a user agnostic approach. It does not store any information regarding any user, the assignment happens in real time, and it does not require any integration with any user information storage. The database of Thomas stores only the experiments' meta-data.
+Thomas is user agnostic. It does not store any information regarding any user, assigns users in real time, and does not require any integration with any user information storage. The Thomas's database stores only the experiments' meta-data.
 
 ### Eligibility control
 
-Without direct access to user information, Thomas uses a different mechanism to control users' eligibility for experiments: when a client calls Thomas assignment service it can pass in a small set of relevant information of the user. Experiments can have some eligibility control criteria that filter users based on the information passed in. 
+Without direct access to user information, Thomas uses a different mechanism to control users' eligibility for experiments: when a client calls Thomas assignment service, it can pass in a small set of relevant information of the user. Experiments can have some eligibility control criteria that filter users based on the information passed in. 
 
 ### Mutually exclusive experiments
 
-Thomas provides an easy way to support mutually exclusive experiments, i.e., users could join one experiment or the other but not both. You can set a numeric range for an experiment. As long as the ranges you set for two experiment don't overlap, they would be mutually exclusive. 
+Thomas provides an easy way to support mutually exclusive experiments, i.e., a user could join either experiment but not both. An experiment can have a numeric range. Two experiments with non-overlapping ranges are mutually exclusive. 
 
 ### Distributed assignment / Spark support
 
@@ -66,7 +76,11 @@ When running on a MacBook Pro, with about two dozens of ongoing experiments, ser
 
 ### Modular and lightweight
 
-Thomas is developed into small modules. The logic and algorithms are in thomas-core. The Http service is provided through a different module - thomas-play-lib. Thomas-client provides a distributed client that can calculate assignments. With this approach, it's easy to create/adopt a different service layer, e.g. gRPC, or a different client implementation. 
+Thomas is developed into small modules. 
+ - thomas-core: Logic and algorithms
+ - thomas-play-lib: Http service
+ - thomas-client: Distributed client that can calculate assignments.
+ With this approach, it's easy to create/adopt a different service layer, e.g. gRPC, or a different client implementation. 
 
 ## Admin UI not included
 


### PR DESCRIPTION
Changes aiming for concision, formality, and readability.

Some line breaks added to separate listing statements.

Explanations reiterated multiple times reduced to the clearest explanation for concision.

