### PR TITLE
Revert "Update logback-classic to 1.4.0"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ lazy val libs =
     .addJVM(name = "henkan-convert",        version = "0.6.5",  org ="com.kailuowang")
     .addJVM(name = "log4cats",              version = "2.3.2",  org = org.typelevel.typeLevelOrg, "log4cats-slf4j", "log4cats-core")
     .addJava(name ="log4j-core",            version = "2.18.0", org = "org.apache.logging.log4j")
-    .addJava(name ="logback-classic",       version = "1.4.0",  org = "ch.qos.logback")
+    .addJava(name ="logback-classic",       version = "1.2.11",  org = "ch.qos.logback")
     .addJVM(name = "mau",                   version = "0.3.1",  org = "com.kailuowang")
     .addJVM(name = "newtype",               version = "0.4.4",  org = "io.estatico")
     .add(   name = "play-json",             version = "2.9.2",  org = "com.typesafe.play")


### PR DESCRIPTION
Reverts iheartradio/thomas#737 causing downstream incompatibility issue since this logback is compiled with an incompatible java as 1.2.11