### PR TITLE
upgrade cache gha to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v4s
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -34,8 +34,17 @@ jobs:
       - name: Set up sbt
         uses: sbt/setup-sbt@v1
 
+      - name: LS
+        run: |
+          ls ~/.sbt
+          ls ~/.ivy2/cache
+          ls ~/.coursier/cache/v1
+          ls ~/.cache/coursier/v1
+          ls ~/AppData/Local/Coursier/Cache/v1
+          ls ~/Library/Caches/Coursier/v1
+
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.sbt
@@ -44,7 +53,7 @@ jobs:
             ~/.cache/coursier/v1
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
-          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+          key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Validation
         run: sbt validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,6 @@ jobs:
           cache: sbt
 
       - uses: sbt/setup-sbt@v1
-      - name: Build and test
-        shell: bash
-        run: sbt -v +test
 
       - name: Cache sbt
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          cache: 'sbt'
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4s
         with:
           java-version: '11'
           distribution: 'adopt'
+
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Cache sbt
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,19 @@ jobs:
 
       - name: LS
         run: |
+          ll -h ~/ || true
           ls ~/.sbt || true
-          ls ~/.ivy2/cache || true
-          ls ~/.coursier/cache/v1 || true
-          ls ~/.cache/coursier/v1 || true
-          ls ~/AppData/Local/Coursier/Cache/v1 || true
+          ls ~/.ivy2/ || true
+          ls ~/.coursier/ || true
+          ls ~/.coursier/cache/ || true
+          ls ~/.cache/ || true
+          ls ~/.cache/coursier/ || true
+          ls ~/AppData/ || true
+          ls ~/AppData/Local/ || true
+          ls ~/AppData/Local/Coursier/ || true
+          ls ~/AppData/Local/Coursier/Cache/ || true
+          ls ~/Library/Caches/ || true
+          ls ~/Library/Caches/Coursier/ || true
           ls ~/Library/Caches/Coursier/v1 || true
 
       - name: Cache sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Set up sbt
         uses: sbt/setup-sbt@v1
 
+      - name: Validation
+        run: sbt validate
+
       - name: LS
         run: |
           ls ~/.sbt || true
@@ -54,6 +57,3 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
-
-      - name: Validation
-        run: sbt validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-          cache: sbt
+          cache: 'sbt'
 
       - uses: sbt/setup-sbt@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -46,4 +46,3 @@ jobs:
 
       - name: Validation
         run: sbt validate
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         java: [adopt@1.11]
 
     runs-on: ${{ matrix.os }}
@@ -43,12 +43,6 @@ jobs:
             ~/AppData/Local/Coursier/Cache/v1
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
-
-      - name: all env commands
-        run: compgen -c | sort | uniq
-
-      - name: docker test
-        run: docker-compose --version
 
       - name: Validation
         run: sbt validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,12 @@ jobs:
 
       - name: LS
         run: |
-          ls ~/.sbt
-          ls ~/.ivy2/cache
-          ls ~/.coursier/cache/v1
-          ls ~/.cache/coursier/v1
-          ls ~/AppData/Local/Coursier/Cache/v1
-          ls ~/Library/Caches/Coursier/v1
+          ls ~/.sbt || true
+          ls ~/.ivy2/cache || true
+          ls ~/.coursier/cache/v1 || true
+          ls ~/.cache/coursier/v1 || true
+          ls ~/AppData/Local/Coursier/Cache/v1 || true
+          ls ~/Library/Caches/Coursier/v1 || true
 
       - name: Cache sbt
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: docker test
-        run: docker-compose --version
-
       - name: all env commands
         run: compgen -c | sort | uniq
+
+      - name: docker test
+        run: docker-compose --version
 
       - name: Validation
         run: sbt validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,5 +44,11 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
+      - name: docker test
+        run: docker-compose --version
+
+      - name: all env commands
+        run: compgen -c | sort | uniq
+
       - name: Validation
         run: sbt validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build and Test
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         java: [adopt@1.11]
 
     runs-on: ${{ matrix.os }}
@@ -27,16 +27,14 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v2
         with:
           java-version: '11'
           distribution: 'adopt'
           cache: 'sbt'
 
-      - uses: sbt/setup-sbt@v1
-
       - name: Cache sbt
-        uses: actions/cache@v4
+        uses: actions/cache@v2
         with:
           path: |
             ~/.sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'adopt'
+          cache: sbt
+
+      - uses: sbt/setup-sbt@v1
+      - name: Build and test
+        shell: bash
+        run: sbt -v +test
 
       - name: Cache sbt
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           distribution: 'adopt'
 
       - name: Cache sbt
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,31 +37,10 @@ jobs:
       - name: Validation
         run: sbt validate
 
-      - name: LS
-        run: |
-          ll -h ~/ || true
-          ls ~/.sbt || true
-          ls ~/.ivy2/ || true
-          ls ~/.coursier/ || true
-          ls ~/.coursier/cache/ || true
-          ls ~/.cache/ || true
-          ls ~/.cache/coursier/ || true
-          ls ~/AppData/ || true
-          ls ~/AppData/Local/ || true
-          ls ~/AppData/Local/Coursier/ || true
-          ls ~/AppData/Local/Coursier/Cache/ || true
-          ls ~/Library/Caches/ || true
-          ls ~/Library/Caches/Coursier/ || true
-          ls ~/Library/Caches/Coursier/v1 || true
-
       - name: Cache sbt
         uses: actions/cache@v4
         with:
           path: |
             ~/.sbt
-            ~/.ivy2/cache
-            ~/.coursier/cache/v1
             ~/.cache/coursier/v1
-            ~/AppData/Local/Coursier/Cache/v1
-            ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v4-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}

--- a/build.sbt
+++ b/build.sbt
@@ -418,7 +418,7 @@ def dockerCompose(
     env: String = ""
   ) = {
   val upCommand = if (upOrDown) "up -d" else "down"
-  s"docker-compose --env-file ./.env$env $upCommand" !
+  s"docker compose --env-file ./.env$env $upCommand" !
 }
 
 lazy val noPublishing = Seq(publish / skip := true)


### PR DESCRIPTION
### Summary

Added: include sbt manually. due to [this](https://github.com/actions/runner-images/issues/10788#issuecomment-2514226771) 
Fixed: upgraded v2 actions to v4. docker-compose to docker compose.
Changed: some cache paths were removed as proved to be non-existent. 

### Test
I already tested it in gha sandbox, see [test PR](https://github.com/iheartradio/ds-gha-sandbox/pull/171). 
This is not a production release. Let's merge it then I can test it.